### PR TITLE
Fix: recursive file search in doxyfile includes benchmark functions a…

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -957,7 +957,8 @@ WARN_LOGFILE           =
 INPUT                  = README.md \
                          src \
                          test \
-                         python
+                         python \
+                         examples
 
 
 # This tag can be used to specify the character encoding of the source files
@@ -1006,7 +1007,7 @@ FILE_PATTERNS          = *.c \
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # EpsteinLib
 
-Authors: Andreas A. Buchheit, Jonathan Busse, Ruben Gutendorf, DevOps: Jan Schmitz
+Authors: Andreas A. Buchheit, Jonathan K. Busse, Ruben Gutendorf, DevOps: Jan Schmitz
 
 Contact: buchheit@num.uni-sb.de
 


### PR DESCRIPTION
# Fix: include more files in docu

## Before

<img width="778" height="295" alt="image" src="https://github.com/user-attachments/assets/262e49ec-e00e-4f96-ae0b-81b6722a9794" />


## Now

<img width="852" height="446" alt="image" src="https://github.com/user-attachments/assets/5355b63f-2a2c-47ab-82a8-651b2be89a6a" />
