### PR TITLE
Julia wrapper

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -353,7 +353,7 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 #
 # Note see also the list of default file extension mappings.
 
-EXTENSION_MAPPING      = py=python
+EXTENSION_MAPPING      = py=python jl=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -957,7 +957,8 @@ WARN_LOGFILE           =
 INPUT                  = README.md \
                          src \
                          test \
-                         python
+                         python \
+                         examples
 
 
 # This tag can be used to specify the character encoding of the source files
@@ -1000,13 +1001,14 @@ INPUT_FILE_ENCODING    =
 
 FILE_PATTERNS          = *.c \
                          *.h \
-                         *.py
+                         *.py \
+                         *.jl
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-
+<!--
 SPDX-FileCopyrightText: 2025 Andreas Buchheit <buchheit@num.uni-sb.de>
 SPDX-FileCopyrightText: 2025 Jan Schmitz <schmitz@num.uni-sb.de>
 SPDX-FileCopyrightText: 2025 Jonathan Busse <jonathan@jbusse.de>

--- a/README.md
+++ b/README.md
@@ -261,10 +261,9 @@ In the `examples/mathematica/` folder, you can find two more mathematica example
 ### in Julia
 
 ```julia
-using Pkg
-
-Pkg.add(url="https://github.com/JuliaBinaryWrappers/Epsteinlib_jll.jl.git")
-using Epsteinlib_jll, Printf
+using Pkg; Pkg.add("Epsteinlib_jll")
+using Epsteinlib_jll
+using Printf
 
 madelung_ref = -1.7475645946331821906362120355443974
 nu, dim = 1.0, UInt32(3)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!--
+<!-
 SPDX-FileCopyrightText: 2025 Andreas Buchheit <buchheit@num.uni-sb.de>
 SPDX-FileCopyrightText: 2025 Jan Schmitz <schmitz@num.uni-sb.de>
 SPDX-FileCopyrightText: 2025 Jonathan Busse <jonathan@jbusse.de>
@@ -230,7 +230,6 @@ In the `examples/python/` folder, you can find two more Python examples:
 These examples, along with the `lattice_sum.py` script, provide a comprehensive overview of how to use EpsteinLib in various scenarios.
 
 
-
 ### in Mathematica
 
 ```mathematica
@@ -258,6 +257,38 @@ In the `examples/mathematica/` folder, you can find two more mathematica example
 
 1. `BenchmarkQuick.wls`: Standalone script that compares the (regularized) Epstein zeta function to known formulas in special cases.
 2. `BenchmarkAndPaperFigures.wls`: Script  that reproduces every figure in [8].
+
+### in Julia
+
+```julia
+using Pkg
+
+Pkg.add(url="https://github.com/JuliaBinaryWrappers/Epsteinlib_jll.jl.git")
+using Epsteinlib_jll, Printf
+
+madelung_ref = -1.7475645946331821906362120355443974
+nu, dim = 1.0, UInt32(3)
+A = [1.0 0.0 0.0;
+     0.0 1.0 0.0;
+     0.0 0.0 1.0] |> vec
+x = [0.0, 0.0, 0.0]
+y = [0.5, 0.5, 0.5]
+
+madelung = ccall((:epsteinZeta, Epsteinlib_jll.libepstein),
+                 ComplexF64,
+                 (Cdouble, Cuint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+                 nu, dim, A, x, y)
+
+println("Madelung sum:\t", real(madelung))
+println("Reference:\t", madelung_ref)
+@printf("Relative error:\t +%.2e\n", abs(madelung_ref - real(madelung))/abs(madelung_ref))
+
+exit(abs(madelung_ref - real(madelung))/abs(madelung_ref) > 1e-14 ? 1 : 0)
+```
+
+The [Julia wrapper](https://github.com/JuliaBinaryWrappers/Epsteinlib_jll.jl) by [dgomezcastro](https://github.com/dgomezcastro) allows direct use of EpsteinLib from Julia and can be run independently of our build system.
+
+
 
 ## Development environment
 We provide a nix devshell to have a reproducible development environment with the same dependencies across different operating systems. Once you have installed and configured nix, starting developing is as easy as running `nix develop`.

--- a/examples/julia/lattice_sum.jl
+++ b/examples/julia/lattice_sum.jl
@@ -25,10 +25,7 @@
 #   Ruben Gutendorf
 ##
 
-using Pkg
-Pkg.activate(temp=true)
-Pkg.add(url="https://github.com/JuliaBinaryWrappers/Epsteinlib_jll.jl.git")
-
+using Pkg; Pkg.add("Epsteinlib_jll")
 using Epsteinlib_jll
 using Printf
 

--- a/examples/julia/lattice_sum.jl
+++ b/examples/julia/lattice_sum.jl
@@ -1,17 +1,29 @@
+# SPDX-FileCopyrightText: 2024 Andreas Buchheit <buchheit@num.uni-sb.de>
 # SPDX-FileCopyrightText: 2025 Jonathan Busse <jonathan@jbusse.de>
-#
-# Original source:
-# https://github.com/epsteinlib/epsteinlib/blob/main/examples/c/lattice_sum.c
-#
-# Original file copyright:
-# // SPDX-FileCopyrightText: 2024 Andreas Buchheit <buchheit@num.uni-sb.de>
-# // SPDX-FileCopyrightText: 2024 Jonathan Busse <jonathan@jbusse.de>
-# // SPDX-FileCopyrightText: 2024 Ruben Gutendorf <ruben.gutendorf@uni-saarland.de>
-# // SPDX-License-Identifier: AGPL-3.0-only
-#
-# Description:
-# Calculates the 3D Madelung constant using the Epstein zeta function
+# SPDX-FileCopyrightText: 2024 Ruben Gutendorf <ruben.gutendorf@uni-saarland.de>
+# SPDX-License-Identifier: AGPL-3.0-only
 
+##
+# @file madelung_test.jl
+# @brief Calculates the Madelung constant.
+#
+# Minimal working example for the Epstein Zeta Library (Julia interface).
+# Requires `Epsteinlib_jll`.
+#
+# Usage:
+# ```bash
+# julia madelung_test.jl
+# ```
+#
+# Reference Madelung constant from literature:
+# sum_{i,j,k∈ℤ} (-1)^(i+j+k) / sqrt(i² + j² + k²)
+#
+# @date 20/10/2025
+# @authors
+#   Andreas Buchheit
+#   Jonathan Busse
+#   Ruben Gutendorf
+##
 
 using Pkg
 Pkg.activate(temp=true)
@@ -20,25 +32,38 @@ Pkg.add(url="https://github.com/JuliaBinaryWrappers/Epsteinlib_jll.jl.git")
 using Epsteinlib_jll
 using Printf
 
-madelung_ref = -1.7475645946331821906362120355443974
+##
+# @brief Calculate Madelung constant and compare to reference.
+#
+# Computes:
+#   sum_{i,j,k∈ℤ} (-1)^(i+j+k) / sqrt(i² + j² + k²)
+# using the Epstein zeta function from the `Epsteinlib_jll` package.
+#
+# @return 0 if relative error < 1e-14, otherwise 1.
+##
+function madelung_test()
+    madelung_ref = -1.7475645946331821906362120355443974
 
-nu  = 1.0
-dim = UInt32(3)
-A = [1.0, 0.0, 0.0,
-     0.0, 1.0, 0.0,
-     0.0, 0.0, 1.0]
-x = [0.0, 0.0, 0.0]
-y = [0.5, 0.5, 0.5]
+    nu  = 1.0
+    dim = UInt32(3)
+    A = [1.0, 0.0, 0.0,
+         0.0, 1.0, 0.0,
+         0.0, 0.0, 1.0]
+    x = [0.0, 0.0, 0.0]
+    y = [0.5, 0.5, 0.5]
 
-madelung = ccall((:epsteinZeta, Epsteinlib_jll.libepstein),
-                 ComplexF64,
-                 (Cdouble, Cuint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
-                 nu, dim, A, x, y)
+    madelung = ccall((:epsteinZeta, Epsteinlib_jll.libepstein),
+                     ComplexF64,
+                     (Cdouble, Cuint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+                     nu, dim, A, x, y)
 
-println("Madelung sum in 3 dimensions:\t", real(madelung))
-println("Reference value:\t\t", madelung_ref)
+    println("Madelung sum in 3 dimensions:\t", real(madelung))
+    println("Reference value:\t\t", madelung_ref)
 
-relerr = abs(madelung_ref - real(madelung)) / abs(madelung_ref)
-@printf("Relative error:\t\t\t +%.2e\n", relerr)
+    relerr = abs(madelung_ref - real(madelung)) / abs(madelung_ref)
+    @printf("Relative error:\t\t\t +%.2e\n", relerr)
 
-exit(relerr > 1e-14 ? 1 : 0)
+    return relerr > 1e-14 ? 1 : 0
+end
+
+exit(madelung_test())

--- a/examples/julia/lattice_sum.jl
+++ b/examples/julia/lattice_sum.jl
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 Jonathan Busse <jonathan@jbusse.de>
+#
+# Original source:
+# https://github.com/epsteinlib/epsteinlib/blob/main/examples/c/lattice_sum.c
+#
+# Original file copyright:
+# // SPDX-FileCopyrightText: 2024 Andreas Buchheit <buchheit@num.uni-sb.de>
+# // SPDX-FileCopyrightText: 2024 Jonathan Busse <jonathan@jbusse.de>
+# // SPDX-FileCopyrightText: 2024 Ruben Gutendorf <ruben.gutendorf@uni-saarland.de>
+# // SPDX-License-Identifier: AGPL-3.0-only
+#
+# Description:
+# Calculates the 3D Madelung constant using the Epstein zeta function
+
+
+using Pkg
+Pkg.activate(temp=true)
+Pkg.add(url="https://github.com/JuliaBinaryWrappers/Epsteinlib_jll.jl.git")
+
+using Epsteinlib_jll
+using Printf
+
+madelung_ref = -1.7475645946331821906362120355443974
+
+nu  = 1.0
+dim = UInt32(3)
+A = [1.0, 0.0, 0.0,
+     0.0, 1.0, 0.0,
+     0.0, 0.0, 1.0]
+x = [0.0, 0.0, 0.0]
+y = [0.5, 0.5, 0.5]
+
+madelung = ccall((:epsteinZeta, Epsteinlib_jll.libepstein),
+                 ComplexF64,
+                 (Cdouble, Cuint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+                 nu, dim, A, x, y)
+
+println("Madelung sum in 3 dimensions:\t", real(madelung))
+println("Reference value:\t\t", madelung_ref)
+
+relerr = abs(madelung_ref - real(madelung)) / abs(madelung_ref)
+@printf("Relative error:\t\t\t +%.2e\n", relerr)
+
+exit(relerr > 1e-14 ? 1 : 0)


### PR DESCRIPTION
# Julia wrapper

EpsteinLib can now be called independently of our build directly from julia, thanks @dgomezcastro !

- [x] minimal working example `examples/julia/lattice_sum.jl`
- [x] update documentation
- [x] availability via `Pkg.add("Epsteinlib_jll")`
- [ ] wait for availability of `epsteinzeta` without `ccall` 