### PR TITLE
Derivatives fix nan in nu der

### DIFF
--- a/build/meson-logs/testlog.junit.xml
+++ b/build/meson-logs/testlog.junit.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
-<testsuites tests="7" errors="0" failures="0"><testsuite name="epsteinlib" tests="7" errors="0" failures="0" skipped="0" time="0.014666318893432617"><testcase name="test_crandall" classname="epsteinlib" time="0.014666318893432617"><system-out>test_crandall_g 
+<testsuites tests="7" errors="0" failures="0"><testsuite name="epsteinlib" tests="7" errors="0" failures="0" skipped="0" time="0.017052888870239258"><testcase name="test_crandall" classname="epsteinlib" time="0.017052888870239258"><system-out>test_crandall_g 
 	 ... processing csv/crandall_g_Ref.csv 
-	 ... 200 out of 200 tests passed with tolerance 1.000000E-13.	    [ Error →  min: 0.000000E+00 | max: 1.128955E-14 | avg: 1.307951E-16 ]</system-out></testcase><testcase name="Minimal working example" classname="epsteinlib" time="0.005872488021850586"><system-out>Madelung sum in 3 dimensions:	 -1.7475645946331821
+	 ... 200 out of 200 tests passed with tolerance 1.000000E-13.	    [ Error →  min: 0.000000E+00 | max: 1.128955E-14 | avg: 1.307951E-16 ]</system-out></testcase><testcase name="Minimal working example" classname="epsteinlib" time="0.007167816162109375"><system-out>Madelung sum in 3 dimensions:	 -1.7475645946331821
 Reference value:		 -1.7475645946331821
-Relative error:			 +0.00e+00</system-out></testcase><testcase name="test_epsteinZeta" classname="epsteinlib" time="0.05266094207763672"><system-out>test_epsteinZeta_epsteinZetaReg 
+Relative error:			 +0.00e+00</system-out></testcase><testcase name="test_epsteinZeta" classname="epsteinlib" time="0.0499880313873291"><system-out>test_epsteinZeta_epsteinZetaReg 
 	 ... processing csv/epsteinZeta_Ref.csv 
 	 ... 300 out of 300 tests passed with tolerance 1.000000E-13.	    [ Error →  min: 0.000000E+00 | max: 1.822089E-15 | avg: 2.766178E-16 ]
 	 ... processing file: csv/epsteinZetaReg_Ref.csv 
@@ -11,7 +11,7 @@ Relative error:			 +0.00e+00</system-out></testcase><testcase name="test_epstein
 test_epsteinZeta_epsteinZetaReg_represent_as_each_other 
 	 ... 200 out of 200 tests passed with tolerance 1.000000E-14.	    [ Error →  min: 0.000000E+00 | max: 9.424515E-16 | avg: 1.707986E-16 ]
 test_epsteinZeta_cutoff 
-	 ... 100 out of 100 tests passed with tolerance 1.000000E-15.</system-out></testcase><testcase name="test_crandall_derivatives" classname="epsteinlib" time="0.12883687019348145"><system-out>start test_polynomial_p 
+	 ... 100 out of 100 tests passed with tolerance 1.000000E-15.</system-out></testcase><testcase name="test_crandall_derivatives" classname="epsteinlib" time="0.17543816566467285"><system-out>start test_polynomial_p 
 	 ... processing csv/polynomial_p_Ref.csv 
 	 ... 100 out of 100 tests passed with tolerance 5.000000E-15.	    [ Error →  min: 0.000000E+00 | max: 1.007550E-15 | avg: 2.450517E-16 ]
 test_polynomial_l 
@@ -40,11 +40,11 @@ test_crandall_g_der_taylor
 	 ... 100 out of 100 tests passed with tolerance 1.000000E-14.	    [ Error →  min: 0.000000E+00 | max: 7.490270E-15 | avg: 3.891047E-16 ]
 test_crandall_gReg_der_taylor 
 	 ... generating test values
-	 ... 100 out of 100 tests passed with tolerance 1.000000E-14.	    [ Error →  min: 0.000000E+00 | max: 7.880421E-16 | avg: 1.069885E-16 ]</system-out></testcase><testcase name="test_epsteinlib" classname="epsteinlib" time="2.243485450744629"><system-err>.................
+	 ... 100 out of 100 tests passed with tolerance 1.000000E-14.	    [ Error →  min: 0.000000E+00 | max: 7.880421E-16 | avg: 1.069885E-16 ]</system-out></testcase><testcase name="test_epsteinlib" classname="epsteinlib" time="3.3201403617858887"><system-err>.................
 ----------------------------------------------------------------------
-Ran 17 tests in 2.099s
+Ran 17 tests in 3.124s
 
-OK</system-err></testcase><testcase name="test_epsteinZetaRegDer" classname="epsteinlib" time="2.9304051399230957"><system-out>test_epsteinZetaRegDer_prototype 
+OK</system-err></testcase><testcase name="test_epsteinZetaRegDer" classname="epsteinlib" time="4.300173044204712"><system-out>test_epsteinZetaRegDer_prototype 
 	 ... processing csv/epsteinZetaRegDer_prototype_Ref.csv 
 	 ... 100 out of 100 tests passed with tolerance 5.000000E-12.	    [ Error →  min: 6.795859E-18 | max: 2.446785E-13 | avg: 7.393677E-15 ]
 test_epsteinZetaRegDer_d2k_prototype 
@@ -55,7 +55,7 @@ test_epsteinZetaRegDer_bain_prototype
 	 ... 12 out of 12 tests passed with tolerance 5.000000E-08.	    [ Error →  min: 4.755118E-16 | max: 2.147164E-09 | avg: 1.962444E-10 ]
 test_epsteinZetaRegDer_taylor 
 	 ... generating test values
-	 ... 100 out of 100 tests passed with tolerance 5.000000E-12.	    [ Error →  min: 0.000000E+00 | max: 2.074108E-15 | avg: 1.713415E-16 ]</system-out></testcase><testcase name="test_setZetaDer" classname="epsteinlib" time="3.0108425617218018"><system-out>test_setZetaDer1D 
+	 ... 100 out of 100 tests passed with tolerance 5.000000E-12.	    [ Error →  min: 0.000000E+00 | max: 2.074108E-15 | avg: 1.713415E-16 ]</system-out></testcase><testcase name="test_setZetaDer" classname="epsteinlib" time="4.409697771072388"><system-out>test_setZetaDer1D 
 	 ... processing csv/setZetaDer_1D_Ref.csv 
 	 ... 100 out of 100 tests passed with tolerance 1.000000E-12.	    [ Error →  min: 0.000000E+00 | max: 7.237383E-13 | avg: 1.490323E-14 ]
 test_setZetaDer_prototype 

--- a/src/crandall.c
+++ b/src/crandall.c
@@ -228,12 +228,14 @@ double complex crandall_g_der(unsigned int dim, double nu, const double *z,
         zArgBoundIt = zArgBounds[betaAbs]; // NOLINT
 
         // summing using Kahan's method
-        auxy = polynomial_p(dim, z, alpha, beta) *
-                   crandall_g(dim, nuIt, z, prefactor, zArgBoundIt) -
-               epsilon;
-        auxt = sum + auxy;
-        epsilon = (auxt - sum) - auxy;
-        sum = auxt;
+        // catch vanishing polynomials
+        double p = polynomial_p(dim, z, alpha, beta);
+        if (p) {
+            auxy = p * crandall_g(dim, nuIt, z, prefactor, zArgBoundIt) - epsilon;
+            auxt = sum + auxy;
+            epsilon = (auxt - sum) - auxy;
+            sum = auxt;
+        }
 
         done = 1;
         for (unsigned int idx = 0; idx < dim; idx++) {

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -432,8 +432,8 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, // NOLINT
         } else {
             res = 0;
         }
-    } else if (fabs(nu - dim) < EPS && dot(dim, y_t2, y_t2) < EPS_ZERO_Y &&
-               variant == 0) {
+    } else if ((variant == 0 || variant == 2) && fabs(nu - dim - alphaAbs) < EPS &&
+               dot(dim, y_t2, y_t2) < EPS_ZERO_Y) {
         res = NAN;
     } else {
         double zArgBound = assignzArgBound(nu);


### PR DESCRIPTION
# nan in even nu

before: `NAN` für `nu=6` und `y=(0,0)` 

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/daac1c16-746a-41e6-9b06-7eed3cdf1292" />

fixed: only evaluate `crandall_g` if the polynomial p does not vanish. Now

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/abf18417-7cb5-480d-82ba-e1b97ddb1737" />

