### PR TITLE
Fix: initialize s1 s2 with NAN so compiler knows its initialized

### DIFF
--- a/src/zeta.c
+++ b/src/zeta.c
@@ -1447,8 +1447,8 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, // NOLINT
     } else {
         double zArgBound = assignzArgBound(nu);
         double zArgBoundReci = assignzArgBound(dim - nu);
-        double complex s1;
-        double complex s2;
+        double complex s1 = NAN;
+        double complex s2 = NAN;
         double complex nc;
         double complex rot = 1;
         double complex xfactor = 1;


### PR DESCRIPTION
 Newer compiler can prove this, older ones can't