### PR TITLE
Derivatives docu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## [0.6] - unreleased
 
-## Added
-- Anisotropic Epstein zeta function and regularized anisotropic Epstein zeta function including a Python and Mathematica bindings.
+### Added
+- Anisotropic Epstein zeta function `epsteinZetaAniso` including Python and Mathematica bindings with testing in `test_setZetaDer` through the related derivatives of set zeta functions for shifted lattices included in `wrappers.h` and `test_setZetaDer.wls`; run `meson test -v -C build/ test_setZetaDer`
+- Regularized anisotropic Epstein zeta function `epsteinZetaAnisoReg` with testing in `test_epsteinZetaRegDer` through the related derivatives of regularized Epstein zeta functions included in `wrappers.h` and `test_epsteinZetaRegDer`; run `meson test -v -C build/ test_epsteinZetaRegDer`
+- New files `hpdyad.c` and `hpdyad.h` implementing high precision dyadic number arithmetic with tests are included in `test_hpdyad.c` and `test_hpdyad.wls`; run `meson test -v -C build/ test_hpdyad`
+- New files `harmonics.c` and `harmonics.h` for high precision computation of harmonic polynomials with tests included in `test_harmonics.c` and `test_harmonics.wls`; run `meson test -v -C build/ test_harmonics`
+- New files `wrappers.c` and `wrappers.h` for functions included in unit tests that do not appear in the core library
 
 ## [0.5.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
+## [0.6] - unreleased
+
+## Added
+- Anisotropic Epstein zeta function and regularized anisotropic Epstein zeta function including a Python and Mathematica bindings.
+
 ## [0.5.1] - 2026-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 ## [0.6] - unreleased
 
 ### Added
-- Anisotropic Epstein zeta function `epsteinZetaAniso` including Python and Mathematica bindings with testing in `test_setZetaDer` through the related derivatives of set zeta functions for shifted lattices included in `wrappers.h` and `test_setZetaDer.wls`; run `meson test -v -C build/ test_setZetaDer`
-- Regularized anisotropic Epstein zeta function `epsteinZetaAnisoReg` with testing in `test_epsteinZetaRegDer` through the related derivatives of regularized Epstein zeta functions included in `wrappers.h` and `test_epsteinZetaRegDer`; run `meson test -v -C build/ test_epsteinZetaRegDer`
-- New files `hpdyad.c` and `hpdyad.h` implementing high precision dyadic number arithmetic with tests are included in `test_hpdyad.c` and `test_hpdyad.wls`; run `meson test -v -C build/ test_hpdyad`
-- New files `harmonics.c` and `harmonics.h` for high precision computation of harmonic polynomials with tests included in `test_harmonics.c` and `test_harmonics.wls`; run `meson test -v -C build/ test_harmonics`
-- New files `wrappers.c` and `wrappers.h` for functions included in unit tests that do not appear in the core library
+- Anisotropic Epstein zeta function `epsteinZetaAniso` including Python and Mathematica bindings with testing in `tests/test_setZetaDer` through the related derivatives of set zeta functions for shifted lattices included in `tests/wrappers.h` and `tests/test_setZetaDer.wls`; run `meson test -v -C build/ test_setZetaDer`
+- Regularized anisotropic Epstein zeta function `epsteinZetaAnisoReg` with testing in `tests/test_epsteinZetaRegDer` through the related derivatives of regularized Epstein zeta functions included in `tests/wrappers.h` and `tests/test_epsteinZetaRegDer`; run `meson test -v -C build/ test_epsteinZetaRegDer`
+- New files `src/hpdyad.c` and `src/hpdyad.h` implementing high precision dyadic number arithmetic with tests included in `tests/test_hpdyad.c` and `tests/test_hpdyad.wls`; run `meson test -v -C build/ test_hpdyad`
+- New files `tests/harmonics.c` and `tests/harmonics.h` for high precision computation of harmonic polynomials with tests included in `tests/test_harmonics.c` and `tests/test_harmonics.wls`; run `meson test -v -C build/ test_harmonics`
+- New files `tests/wrappers.c` and `tests/wrappers.h` for functions included in unit tests that do not appear in the core library
+- New file `tests/benchmark_aniso_timing.c`, which builds to an executable of the same name that benchmarks the evaluation times of the anisotropic Epstein zeta function
 
 ## [0.5.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
+## [0.5.2] - unreleased
+
+### Changed
+- Moved tests from `src/tests/` to `tests/`
+
+### Added
+- Standalone example notebook `examples/IMAFigures.wls` reproducing the results of the IMA Journal of Numerical Analysis manuscript which deprecates `examples/BenchmarkQuick.wls` and `examples/BenchmarkAndPaperFigures.wls`
+
 ## [0.5.1] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ EpsteinLib is a C library designed for the fast and efficient computation of the
 
 Originally studied by Epstein [1,2], the Epstein zeta function forms the basis for computing general multidimensional lattice sums in classical and quantum physics applications [3]. Together with its regularization, it serves as the central ingredient in the singular Euler-Maclaurin (SEM) expansion, which generalizes the 300-year-old Euler summation formula to lattice sums in higher dimensions with physically relevant power-law interactions [4-5]. An efficiently computable representation of the Epstein zeta function is provided in [6,7,8]. In [8], we discuss in detail the analytical properties of the Epstein zeta function and present an algorithm for its computation, complete with error bounds.
 
+The anisotropic Epstein zeta function that appears in vector derivatives of Epstein zeta functions is also included in this library.
 ## Epstein zeta function
 For a $d$-dimensional lattice $\Lambda=A\mathbb Z^d$, with $A\in \mathbb R^{d\times d}$ regular, $\boldsymbol x,\boldsymbol y \in \mathbb R^d$, and $\nu \in \mathbb C$, the Epstein zeta function is defined by the Dirichlet series
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Z_{\Lambda,\nu}(\boldsymbol x,\boldsymbol y)
 +|\boldsymbol \alpha|,
 $$
 
-meromorphically continued to $\nu \in \mathbb C$; where $|\boldsymbol{\alpha}|=\alpha_1+\ldots+\alpha_d$.  Here, we recover the Epstein zeta function for $\boldsymbol \alpha=\boldsymbol 0$. The anisotropic Epstein zeta function is closely related to the partial vector derivatives of the Epstein zeta function. In particular, the $\boldsymbol{\alpha}$ derivatives of the Epstein zeta function with respect to the wave vector $\boldsymbol{y}$ can be obtained by
+meromorphically continued to $\nu \in \mathbb C$; where we define $|\boldsymbol{\alpha}|=\alpha_1+\ldots+\alpha_d$.  Here, we recover the Epstein zeta function for $\boldsymbol \alpha=\boldsymbol 0$. The anisotropic Epstein zeta function is closely related to the partial vector derivatives of the Epstein zeta function. In particular, the $\boldsymbol{\alpha}$ derivatives of the Epstein zeta function with respect to the wave vector $\boldsymbol{y}$ can be obtained by
 
 ```math
 \nabla_{\boldsymbol{y}}^{\boldsymbol{\alpha}}
@@ -158,7 +158,7 @@ Z_{\Lambda,\nu,\boldsymbol\beta}(\boldsymbol x,\boldsymbol y)
 ```
 
 where the summation goes over $`\{\boldsymbol \beta\in\mathbb N_0^d:\beta_i\le\alpha_i,\ 1\le i\le d\}`$
-and where we define $|\boldsymbol\alpha|=\alpha_1+\ldots+\alpha_d$,
+and where we define
 $`\nabla^{\boldsymbol\alpha}_{\boldsymbol y}=\partial_{y_1}^{\alpha_1}\ldots\partial_{y_d}^{\alpha_d}`$, and
 $`\binom{\boldsymbol\alpha}{\boldsymbol\beta}=\binom{\alpha_1}{\beta_1}\ldots\binom{\alpha_d}{\beta_d}.`$
 

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -907,21 +907,21 @@ static double complex summation_harmonic(
 
 /**
  * @brief calculates the (regularized) Epstein zeta function as well es the
- * derivatives of the set zeta function.
- * @param[in] nu: exponent for the Epstein zeta function.
+ * derivatives of the (regularized) set zeta function with a prefactor.
+ * @param[in] nu: exponent.
  * @param[in] dim: dimension of the input vectors.
- * @param[in] m: matrix that transforms the lattice in the Epstein zeta
- * function.
- * @param[in] x: x vector of the Epstein zeta function.
- * @param[in] y: y vector of the Epstein zeta function.
+ * @param[in] m: matrix that transforms the lattice .
+ * @param[in] x: shift vector.
+ * @param[in] y: wave vector.
  * @param[in] lambda: relative weight of the sums in Crandall's formula.
  * @param[in] variant:
- *      0 for no regularization
- *      1 for the regularization
- *      2 for set zeta derivatives (divided by (-2 pi i)^|alpha|)
- *      3 for the regularized set zeta derivatives (divided by (-2 pi i)^|alpha|).
- * @param[in] alpha: multiindex for the derivatives of the set zeta function. *
- * @return function value of the regularized Epstein zeta.
+ *      0 for the Epstein zeta function
+ *      1 for the regularized Epstein zeta function
+ *      2 for the set zeta derivatives (divided by (-2 pi i)^|alpha|)
+ *      3 for the derivatives of the regularized Epstein zeta function (divided by
+ * (-2 pi i)^|alpha|).
+ * @param[in] alpha: multiindex for the derivatives.
+ * @return function value.
  */
 double complex epsteinZetaInternal(double nu, unsigned int dim, // NOLINT
                                    const double *m, const double *x, const double *y,

--- a/tests/csv.license
+++ b/tests/csv.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2025 Jonathan Busse <jonathan@jbusse.de>
-
-SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
Redo: [Better documentation of anisotropic Epstein zeta throughout](https://github.com/epsteinlib/epsteinlib/pull/87) (there, initially wrong target branch caused long commit history in web UI)