### PR TITLE
Fix: Zreg at nu = 0 with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ### Fixed
 - Removed spurious phase factor of the regularized Epstein zeta function at $\nu=0$ and $\boldsymbol{x}\in\Lambda$, now returns $-1$ instead of $-e^{-2\pi i\boldsymbol{x}\cdot\boldsymbol{y}}$
+- Mathematica bindings `EpsteinZeta` and `EpsteinZetaReg` no longer accept non-square `A`, which previously produced silently wrong results
 
 ## [0.5.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
+## [0.5.2] - unreleased
+
+### Changed
+- Moved tests from `src/tests/` to `tests/`
+
+### Added
+- Standalone example notebook `examples/IMAFigures.wls` reproducing the results of the IMA Journal of Numerical Analysis manuscript which deprecates `examples/BenchmarkQuick.wls` and `examples/BenchmarkAndPaperFigures.wls`
+
 ## [0.5.1] - 2026-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Changelog
 
+## [0.5.2] - unreleased
+
+### Fixed
+- Removed spurious phase factor of the regularized Epstein zeta function at $\nu=0$ and $\boldsymbol{x}\in\Lambda$, now returns $-1$ instead of $-e^{-2\pi i\boldsymbol{x}\cdot\boldsymbol{y}}$
+
 ## [0.5.1] - 2026-04-27
 
 ### Changed

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -58,16 +58,18 @@ If[Head[foreignFunctionEpsteinZetaReg] =!= ForeignFunction,
   Print["ForeignFunctionLoad for epstein_zeta_reg_mathematica_call failed."]
 ]
 
-
-(* True when the library wrote something that is not a usable machine
-   double (NaN, inf, or an unconvertible read). *)
-badReadQ[u_] := ! MachineNumberQ[u];
-
+(* For checking nan output of C function *)
+NaNQ = ResourceFunction["NaNQ"];
 
 (* Internal routine for C function access *)
 epsteinZetaInternal[\[Nu]_, A_, x_, y_, function_, foreignFunction_] :=
 Module[
-  {d = Length[A], aMemory, xMemory, yMemory, zetaMemory, status, realPart, imagPart},
+  {d = Length[A], failed = False, aMemory, xMemory, yMemory, zetaMemory, epsteinZetaObject, realPart, imagPart},
+
+  (* Dimensional error handling *)
+  If[Length[x] != d, Message[function::dimerrx, d, Length[x], x, y, A]; failed = True];
+  If[Length[y] != d, Message[function::dimerry, d, Length[y], x, y, A]; failed = True];
+  If[failed, Return[$Failed]];
 
   aMemory = RawMemoryAllocate["CDouble", d * d];
   xMemory = RawMemoryAllocate["CDouble", d];
@@ -78,72 +80,53 @@ Module[
   Table[RawMemoryWrite[aMemory, N[A[[i,j]]], d*(i-1)+(j-1)], {i, 1, d}, {j, 1, d}];
 
   zetaMemory = RawMemoryAllocate["CDouble", 2];
-  status = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
+  epsteinZetaObject = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
 
-  Which[
-    status === $Failed,
-      Message[function::marshal, \[Nu], A, x, y]; $Failed,
-    status =!= 0,
-      Message[function::cfail, status, \[Nu], A, x, y]; $Failed,
-    True,
-      realPart = RawMemoryRead[zetaMemory, 0];
-      imagPart = RawMemoryRead[zetaMemory, 1];
-      If[badReadQ[realPart] || badReadQ[imagPart],
-        ComplexInfinity,
-        realPart + I*imagPart]
-   ]
+  realPart = RawMemoryRead[zetaMemory, 0];
+  imagPart = RawMemoryRead[zetaMemory, 1];
+
+  If[PossibleZeroQ@epsteinZetaObject,
+    If[!NaNQ[N@realPart] && !NaNQ[N@imagPart],
+      realPart + I*imagPart,
+      ComplexInfinity
+    ],
+    Print["Error: Calculation failed"];
+    Print["Input parameters: \[Nu] = ", \[Nu], ", A = ", A, ", x = ", x, ", y = ", y];
+    Print["Dimension: ", d];
+    "An Error occurred.";
+    epsteinZetaObject
+  ]
 ]
 
 
 (* Dimensional error handling messages *)
-EpsteinZeta::cfail = "The library returned error status `1` for \[Nu] = `2`, A = `3`, x = `4`, y = `5`.";
-EpsteinZeta::marshal = "The arguments \[Nu] = `1`, A = `2`, x = `3`, y = `4` could not be passed to the library. \
-\[Nu] and every entry of A, x and y must be real and representable as a machine double.";
-EpsteinZetaReg::cfail = EpsteinZeta::cfail;
-EpsteinZetaReg::marshal = EpsteinZeta::marshal;
-
-
-(* *)
-numericVectorQ[v_] := VectorQ[v, NumericQ];
-numericSquareMatrixQ[A_] := SquareMatrixQ[A] && MatrixQ[A, NumericQ];
+EpsteinZeta::dimerrx = "Input vector x = `3` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
+EpsteinZeta::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
+EpsteinZetaReg::dimerrx = "Input vector x = `3` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
+EpsteinZetaReg::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
 
 
 (* Define the public Epstein zeta functions *)
-EpsteinZeta[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
-    Length[x] == Length[y] == Length[A] :=
-  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZeta, foreignFunctionEpsteinZeta]
+EpsteinZeta[\[Nu]_?NumericQ, A_/;MatrixQ[A] && AllTrue[Flatten[A], NumericQ], x_/;VectorQ[x] && AllTrue[x, NumericQ], y_/;VectorQ[y] && AllTrue[y, NumericQ]] := epsteinZetaInternal[\[Nu], A, x, y, EpsteinZeta, foreignFunctionEpsteinZeta]
 
-EpsteinZetaReg[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
-    Length[x] == Length[y] == Length[A] :=
-  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
+EpsteinZetaReg[\[Nu]_?NumericQ, A_/;MatrixQ[A] && AllTrue[Flatten[A], NumericQ], x_/;VectorQ[x] && AllTrue[x, NumericQ], y_/;VectorQ[y] && AllTrue[y, NumericQ]] := epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
 
 
-
+(* Check if package loaded successfully *)
 epsteinLoad::info = "`1`";
-epsteinLoad::selftest = "EpsteinZeta` loaded but failed its self-test: `1`. \
-The library is returning incorrect results; do not trust its output.";
-
 If[libPath =!= $Failed &&
    Head[foreignFunctionEpsteinZeta] === ForeignFunction &&
-   Head[foreignFunctionEpsteinZetaReg] === ForeignFunction,
-
-  With[{failed = Keys @ Select[<|
-      "EpsteinZeta[-2,{{1}},{1},{0}] vanishes"    -> PossibleZeroQ[EpsteinZeta[-2, {{1}}, {1}, {0}]],
-      "EpsteinZetaReg[-2,{{1}},{1},{0}] vanishes" -> PossibleZeroQ[EpsteinZetaReg[-2, {{1}}, {1}, {0}]],
-      "EpsteinZeta has a pole at \[Nu] = d"       -> (EpsteinZeta[1, {{1}}, {0}, {0}] === ComplexInfinity),
-      "EpsteinZetaReg is finite at \[Nu] = d"     -> MachineNumberQ[EpsteinZetaReg[1, {{1}}, {0}, {0}]]
-    |>, Not]},
-
-    If[failed === {},
-      Message[epsteinLoad::info,
-        "The (regularized) Epstein zeta function can be called using:
+   Head[foreignFunctionEpsteinZetaReg] === ForeignFunction &&
+   PossibleZeroQ[EpsteinZeta[-2, {{1}}, {1}, {0}]] &&
+   PossibleZeroQ[EpsteinZetaReg[-2, {{1}}, {1}, {0}]],
+  Message[epsteinLoad::info,
+   "The (regularized) Epstein zeta function can be called using:
   EpsteinZeta[\[Nu], A, x, y]
   EpsteinZetaReg[\[Nu], A, x, y]
 Where:
   \[Nu] is a real number
-  A is a d\[Times]d square matrix
-  x and y are vectors of length d"],
-      Message[epsteinLoad::selftest, failed]]]
+  A is a square matrix
+  x and y are vectors of the same dimension as A"]
 ]
 
 End[];

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -111,19 +111,27 @@ EpsteinZetaReg[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?n
 
 (* Check if package loaded successfully *)
 epsteinLoad::info = "`1`";
+epsteinLoad::broken = "The Epstein zeta library at `1` loaded but failed its self-test. \
+Results cannot be trusted! Check that the library is current and built for this platform.";
+
 If[libPath =!= $Failed &&
    Head[foreignFunctionEpsteinZeta] === ForeignFunction &&
-   Head[foreignFunctionEpsteinZetaReg] === ForeignFunction &&
-   PossibleZeroQ[EpsteinZeta[-2, {{1}}, {1}, {0}]] &&
-   PossibleZeroQ[EpsteinZetaReg[-2, {{1}}, {1}, {0}]],
-  Message[epsteinLoad::info,
-   "The (regularized) Epstein zeta function can be called using:
+   Head[foreignFunctionEpsteinZetaReg] === ForeignFunction,
+
+  If[PossibleZeroQ[EpsteinZeta[-2, {{1}}, {1}, {0}]] &&
+     PossibleZeroQ[EpsteinZetaReg[-2, {{1}}, {1}, {0}]] &&
+     EpsteinZeta[1, {{1}}, {0}, {0}] =!= EpsteinZetaReg[1, {{1}}, {0}, {0}],
+
+    Message[epsteinLoad::info,
+     "The (regularized) Epstein zeta function can be called using:
   EpsteinZeta[\[Nu], A, x, y]
   EpsteinZetaReg[\[Nu], A, x, y]
 Where:
   \[Nu] is a real number
   A is a square matrix
-  x and y are vectors of the same dimension as A"]
+  x and y are vectors of the same dimension as A"],
+
+    Message[epsteinLoad::broken, libPath]]
 ]
 
 End[];

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -106,10 +106,18 @@ EpsteinZetaReg::dimerrx = "Input vector x = `3` has incorrect dimension. Expecte
 EpsteinZetaReg::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
 
 
-(* Define the public Epstein zeta functions *)
-EpsteinZeta[\[Nu]_?NumericQ, A_/;MatrixQ[A] && AllTrue[Flatten[A], NumericQ], x_/;VectorQ[x] && AllTrue[x, NumericQ], y_/;VectorQ[y] && AllTrue[y, NumericQ]] := epsteinZetaInternal[\[Nu], A, x, y, EpsteinZeta, foreignFunctionEpsteinZeta]
+(* Check arguments helpers *)
+numericSquareMatrixQ[A_] := SquareMatrixQ[A] && MatrixQ[A, NumericQ];
+numericVectorQ[v_] := VectorQ[v, NumericQ];
 
-EpsteinZetaReg[\[Nu]_?NumericQ, A_/;MatrixQ[A] && AllTrue[Flatten[A], NumericQ], x_/;VectorQ[x] && AllTrue[x, NumericQ], y_/;VectorQ[y] && AllTrue[y, NumericQ]] := epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
+(* Define the public Epstein zeta functions *)
+EpsteinZeta[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
+    Length[x] == Length[y] == Length[A] :=
+  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZeta, foreignFunctionEpsteinZeta]
+
+EpsteinZetaReg[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
+    Length[x] == Length[y] == Length[A] :=
+  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
 
 
 (* Check if package loaded successfully *)

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -108,21 +108,32 @@ EpsteinZetaReg[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?n
   epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
 
 
-(* Check if package loaded successfully *)
+
 epsteinLoad::info = "`1`";
+epsteinLoad::selftest = "EpsteinZeta` loaded but failed its self-test: `1`. \
+The library is returning incorrect results; do not trust its output.";
+
 If[libPath =!= $Failed &&
    Head[foreignFunctionEpsteinZeta] === ForeignFunction &&
-   Head[foreignFunctionEpsteinZetaReg] === ForeignFunction &&
-   PossibleZeroQ[EpsteinZeta[-2, {{1}}, {1}, {0}]] &&
-   PossibleZeroQ[EpsteinZetaReg[-2, {{1}}, {1}, {0}]],
-  Message[epsteinLoad::info,
-   "The (regularized) Epstein zeta function can be called using:
+   Head[foreignFunctionEpsteinZetaReg] === ForeignFunction,
+
+  With[{failed = Keys @ Select[<|
+      "EpsteinZeta[-2,{{1}},{1},{0}] vanishes"    -> PossibleZeroQ[EpsteinZeta[-2, {{1}}, {1}, {0}]],
+      "EpsteinZetaReg[-2,{{1}},{1},{0}] vanishes" -> PossibleZeroQ[EpsteinZetaReg[-2, {{1}}, {1}, {0}]],
+      "EpsteinZeta has a pole at \[Nu] = d"       -> (EpsteinZeta[1, {{1}}, {0}, {0}] === ComplexInfinity),
+      "EpsteinZetaReg is finite at \[Nu] = d"     -> MachineNumberQ[EpsteinZetaReg[1, {{1}}, {0}, {0}]]
+    |>, Not]},
+
+    If[failed === {},
+      Message[epsteinLoad::info,
+        "The (regularized) Epstein zeta function can be called using:
   EpsteinZeta[\[Nu], A, x, y]
   EpsteinZetaReg[\[Nu], A, x, y]
 Where:
   \[Nu] is a real number
-  A is a square matrix
-  x and y are vectors of the same dimension as A"]
+  A is a d\[Times]d square matrix
+  x and y are vectors of length d"],
+      Message[epsteinLoad::selftest, failed]]]
 ]
 
 End[];

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -64,12 +64,7 @@ NaNQ = ResourceFunction["NaNQ"];
 (* Internal routine for C function access *)
 epsteinZetaInternal[\[Nu]_, A_, x_, y_, function_, foreignFunction_] :=
 Module[
-  {d = Length[A], failed = False, aMemory, xMemory, yMemory, zetaMemory, epsteinZetaObject, realPart, imagPart},
-
-  (* Dimensional error handling *)
-  If[Length[x] != d, Message[function::dimerrx, d, Length[x], x, y, A]; failed = True];
-  If[Length[y] != d, Message[function::dimerry, d, Length[y], x, y, A]; failed = True];
-  If[failed, Return[$Failed]];
+  {d = Length[A], aMemory, xMemory, yMemory, zetaMemory, status, realPart, imagPart},
 
   aMemory = RawMemoryAllocate["CDouble", d * d];
   xMemory = RawMemoryAllocate["CDouble", d];
@@ -80,30 +75,24 @@ Module[
   Table[RawMemoryWrite[aMemory, N[A[[i,j]]], d*(i-1)+(j-1)], {i, 1, d}, {j, 1, d}];
 
   zetaMemory = RawMemoryAllocate["CDouble", 2];
-  epsteinZetaObject = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
+  status = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
 
   realPart = RawMemoryRead[zetaMemory, 0];
   imagPart = RawMemoryRead[zetaMemory, 1];
 
-  If[PossibleZeroQ@epsteinZetaObject,
+  If[PossibleZeroQ@status,
     If[!NaNQ[N@realPart] && !NaNQ[N@imagPart],
       realPart + I*imagPart,
       ComplexInfinity
     ],
-    Print["Error: Calculation failed"];
-    Print["Input parameters: \[Nu] = ", \[Nu], ", A = ", A, ", x = ", x, ", y = ", y];
-    Print["Dimension: ", d];
-    "An Error occurred.";
-    epsteinZetaObject
+    Message[function::cfail, status, \[Nu], A, x, y];
+    $Failed
   ]
 ]
 
-
 (* Dimensional error handling messages *)
-EpsteinZeta::dimerrx = "Input vector x = `3` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
-EpsteinZeta::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
-EpsteinZetaReg::dimerrx = "Input vector x = `3` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
-EpsteinZetaReg::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
+EpsteinZeta::cfail = "The library call failed with status `1` for \[Nu] = `2`, A = `3`, x = `4`, y = `5`.";
+EpsteinZetaReg::cfail = EpsteinZeta::cfail;
 
 
 (* Check arguments helpers *)

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -58,8 +58,10 @@ If[Head[foreignFunctionEpsteinZetaReg] =!= ForeignFunction,
   Print["ForeignFunctionLoad for epstein_zeta_reg_mathematica_call failed."]
 ]
 
-(* For checking nan output of C function *)
-NaNQ = ResourceFunction["NaNQ"];
+
+(* True when the library wrote something that is not a usable machine
+   double (NaN, inf, or an unconvertible read). *)
+badReadQ[u_] := ! MachineNumberQ[u];
 
 
 (* Internal routine for C function access *)
@@ -78,19 +80,27 @@ Module[
   zetaMemory = RawMemoryAllocate["CDouble", 2];
   status = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
 
-  If[status =!= 0,
-    Message[function::cfail, status, \[Nu], A, x, y]; $Failed,
-
-    realPart = RawMemoryRead[zetaMemory, 0];
-    imagPart = RawMemoryRead[zetaMemory, 1];
-    If[NaNQ[N@realPart] || NaNQ[N@imagPart], ComplexInfinity, realPart + I*imagPart]
-  ]
+  Which[
+    status === $Failed,
+      Message[function::marshal, \[Nu], A, x, y]; $Failed,
+    status =!= 0,
+      Message[function::cfail, status, \[Nu], A, x, y]; $Failed,
+    True,
+      realPart = RawMemoryRead[zetaMemory, 0];
+      imagPart = RawMemoryRead[zetaMemory, 1];
+      If[badReadQ[realPart] || badReadQ[imagPart],
+        ComplexInfinity,
+        realPart + I*imagPart]
+   ]
 ]
 
 
 (* Dimensional error handling messages *)
-EpsteinZeta::cfail = "The library call failed with status `1` for \[Nu] = `2`, A = `3`, x = `4`, y = `5`.";
+EpsteinZeta::cfail = "The library returned error status `1` for \[Nu] = `2`, A = `3`, x = `4`, y = `5`.";
+EpsteinZeta::marshal = "The arguments \[Nu] = `1`, A = `2`, x = `3`, y = `4` could not be passed to the library. \
+\[Nu] and every entry of A, x and y must be real and representable as a machine double.";
 EpsteinZetaReg::cfail = EpsteinZeta::cfail;
+EpsteinZetaReg::marshal = EpsteinZeta::marshal;
 
 
 (* *)

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -105,7 +105,7 @@ EpsteinZeta[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?nume
 
 EpsteinZetaReg[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
     Length[x] == Length[y] == Length[A] :=
-  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZeta]
+  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
 
 
 (* Check if package loaded successfully *)

--- a/mathematica/EpsteinZeta.wl
+++ b/mathematica/EpsteinZeta.wl
@@ -61,15 +61,11 @@ If[Head[foreignFunctionEpsteinZetaReg] =!= ForeignFunction,
 (* For checking nan output of C function *)
 NaNQ = ResourceFunction["NaNQ"];
 
+
 (* Internal routine for C function access *)
 epsteinZetaInternal[\[Nu]_, A_, x_, y_, function_, foreignFunction_] :=
 Module[
-  {d = Length[A], failed = False, aMemory, xMemory, yMemory, zetaMemory, epsteinZetaObject, realPart, imagPart},
-
-  (* Dimensional error handling *)
-  If[Length[x] != d, Message[function::dimerrx, d, Length[x], x, y, A]; failed = True];
-  If[Length[y] != d, Message[function::dimerry, d, Length[y], x, y, A]; failed = True];
-  If[failed, Return[$Failed]];
+  {d = Length[A], aMemory, xMemory, yMemory, zetaMemory, status, realPart, imagPart},
 
   aMemory = RawMemoryAllocate["CDouble", d * d];
   xMemory = RawMemoryAllocate["CDouble", d];
@@ -80,36 +76,36 @@ Module[
   Table[RawMemoryWrite[aMemory, N[A[[i,j]]], d*(i-1)+(j-1)], {i, 1, d}, {j, 1, d}];
 
   zetaMemory = RawMemoryAllocate["CDouble", 2];
-  epsteinZetaObject = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
+  status = foreignFunction[zetaMemory, N[\[Nu]], d, aMemory, xMemory, yMemory];
 
-  realPart = RawMemoryRead[zetaMemory, 0];
-  imagPart = RawMemoryRead[zetaMemory, 1];
+  If[status =!= 0,
+    Message[function::cfail, status, \[Nu], A, x, y]; $Failed,
 
-  If[PossibleZeroQ@epsteinZetaObject,
-    If[!NaNQ[N@realPart] && !NaNQ[N@imagPart],
-      realPart + I*imagPart,
-      ComplexInfinity
-    ],
-    Print["Error: Calculation failed"];
-    Print["Input parameters: \[Nu] = ", \[Nu], ", A = ", A, ", x = ", x, ", y = ", y];
-    Print["Dimension: ", d];
-    "An Error occurred.";
-    epsteinZetaObject
+    realPart = RawMemoryRead[zetaMemory, 0];
+    imagPart = RawMemoryRead[zetaMemory, 1];
+    If[NaNQ[N@realPart] || NaNQ[N@imagPart], ComplexInfinity, realPart + I*imagPart]
   ]
 ]
 
 
 (* Dimensional error handling messages *)
-EpsteinZeta::dimerrx = "Input vector x = `3` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
-EpsteinZeta::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
-EpsteinZetaReg::dimerrx = "Input vector x = `3` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
-EpsteinZetaReg::dimerry = "Input vector y = `4` has incorrect dimension. Expected dimension `1` (matching `1`×`1` matrix A = `5`), but got `2`."
+EpsteinZeta::cfail = "The library call failed with status `1` for \[Nu] = `2`, A = `3`, x = `4`, y = `5`.";
+EpsteinZetaReg::cfail = EpsteinZeta::cfail;
+
+
+(* *)
+numericVectorQ[v_] := VectorQ[v, NumericQ];
+numericSquareMatrixQ[A_] := SquareMatrixQ[A] && MatrixQ[A, NumericQ];
 
 
 (* Define the public Epstein zeta functions *)
-EpsteinZeta[\[Nu]_?NumericQ, A_/;MatrixQ[A] && AllTrue[Flatten[A], NumericQ], x_/;VectorQ[x] && AllTrue[x, NumericQ], y_/;VectorQ[y] && AllTrue[y, NumericQ]] := epsteinZetaInternal[\[Nu], A, x, y, EpsteinZeta, foreignFunctionEpsteinZeta]
+EpsteinZeta[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
+    Length[x] == Length[y] == Length[A] :=
+  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZeta, foreignFunctionEpsteinZeta]
 
-EpsteinZetaReg[\[Nu]_?NumericQ, A_/;MatrixQ[A] && AllTrue[Flatten[A], NumericQ], x_/;VectorQ[x] && AllTrue[x, NumericQ], y_/;VectorQ[y] && AllTrue[y, NumericQ]] := epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZetaReg]
+EpsteinZetaReg[\[Nu]_?NumericQ, A_?numericSquareMatrixQ, x_?numericVectorQ, y_?numericVectorQ] /;
+    Length[x] == Length[y] == Length[A] :=
+  epsteinZetaInternal[\[Nu], A, x, y, EpsteinZetaReg, foreignFunctionEpsteinZeta]
 
 
 (* Check if package loaded successfully *)

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -262,7 +262,11 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, // NOLINT
     double complex res;
     if (nu < 1 && fabs((nu / 2.) - nearbyint(nu / 2.)) < EPS) {
         if (dot(dim, x_t2, x_t2) == 0 && nu == 0) {
-            res = -1 * cexp(-2 * M_PI * I * dot(dim, x_t1, y_t2));
+            if (reg) {
+                res = -1; // reg already carries phase by definition
+            } else {
+                res = -cexp(-2 * M_PI * I * dot(dim, x_t1, y_t2));
+            }
         } else {
             res = 0;
         }

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -261,7 +261,7 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, // NOLINT
     // handle special case of non-positive integer values nu.
     double complex res;
     if (nu < 1 && fabs((nu / 2.) - nearbyint(nu / 2.)) < EPS) {
-        if (dot(dim, x_t2, x_t2) == 0 && nu == 0) {
+        if (dot(dim, x_t2, x_t2) <= EPS_ZERO_Y && nu == 0) {
             if (reg) {
                 res = -1; // reg already carries phase by definition
             } else {

--- a/tests/test_epsteinZeta.c
+++ b/tests/test_epsteinZeta.c
@@ -89,7 +89,7 @@ void reportEpsteinZetaError(double complex valZeta, double complex valZetaReg,
     printf("\n");
     printf("Warning! ");
     printf("epsteinZeta:");
-    printf(" %0*.16lf %+.16lf I (epsteinZeta) \n\t\t  != "
+    printf(" %0*.16lf %+.16lf I (epsteinZeta) \n\t\t   != "
            "%.16lf "
            "%+.16lf I (epsteinZetaReg representation)\n",
            4, creal(valZeta), cimag(valZeta), creal(valZetaReg), cimag(valZetaReg));
@@ -670,7 +670,7 @@ int test_epsteinZetaReg_random_matrices(void) { // NOLINT
  * @return number of failed tests.
  * tests pass.
  */
-static int test_epsteinZeta_epsteinZetaReg_represent_as_each_other() {
+static int test_epsteinZeta_epsteinZetaReg_represent_as_each_other() { // NOLINT
     printf("%s ", __func__);
     double errorAbs;
     double errorRel;
@@ -686,7 +686,7 @@ static int test_epsteinZeta_epsteinZetaReg_represent_as_each_other() {
     double errMax = NAN;
     double errSum = 0.;
 
-    double tol = 5 * pow(10, -15);
+    double tol = 5 * pow(10, -14);
     unsigned int dim = 2;
     double m[] = {3. / 2, 1. / 5, 1. / 4, 1.};
     double x[] = {0.1, 0.2};
@@ -745,6 +745,54 @@ static int test_epsteinZeta_epsteinZetaReg_represent_as_each_other() {
         }
         totalTests++;
     }
+
+    // test identity for x a nonzero lattice vector (identity lattice, so the
+    // projection x_t2 is exactly zero and the nu = 0 special branch is reached)
+    double mLat[] = {1., 0., 0., 1.};
+    double xLat[] = {1., 0.};
+    double yLat[] = {0.3, 0.4};
+    double volLat = 1.;
+    for (int i = 0; i < 100; i++) {
+        nu = -8.45 + (double)i / 5.;
+        valZeta = epsteinZeta(nu, dim, mLat, xLat, yLat);
+        valZetaReg = cexp(-2 * M_PI * I * dot(dim, xLat, yLat)) *
+                     (epsteinZetaReg(nu, dim, mLat, xLat, yLat) +
+                      sHat(nu, dim, yLat) / volLat);
+        errorAbs = errAbs(valZeta, valZetaReg);
+        errorRel = errRel(valZeta, valZetaReg);
+        errorMaxAbsRel = (errorAbs < errorRel) ? errorAbs : errorRel;
+        errMin = (errMin < errorMaxAbsRel) ? errMin : errorMaxAbsRel;
+        errMax = (errMax > errorMaxAbsRel) ? errMax : errorMaxAbsRel;
+        errSum += errorMaxAbsRel;
+        if (errorMaxAbsRel < tol) {
+            testsPassed++;
+        } else {
+            reportEpsteinZetaError(valZeta, valZetaReg, errorMaxAbsRel, tol, mLat,
+                                   dim, nu, xLat, yLat);
+        }
+        totalTests++;
+    }
+
+    // nu = 0 exactly, x a nonzero lattice vector: Z_0 = -exp(-2 pi i x.y),
+    // sHat_0 = 0, hence Z^reg_0 = -1 independently of x and y
+    nu = 0.;
+    valZeta = epsteinZeta(nu, dim, mLat, xLat, yLat);
+    valZetaReg =
+        cexp(-2 * M_PI * I * dot(dim, xLat, yLat)) *
+        (epsteinZetaReg(nu, dim, mLat, xLat, yLat) + sHat(nu, dim, yLat) / volLat);
+    errorAbs = errAbs(valZeta, valZetaReg);
+    errorRel = errRel(valZeta, valZetaReg);
+    errorMaxAbsRel = (errorAbs < errorRel) ? errorAbs : errorRel;
+    errMin = (errMin < errorMaxAbsRel) ? errMin : errorMaxAbsRel;
+    errMax = (errMax > errorMaxAbsRel) ? errMax : errorMaxAbsRel;
+    errSum += errorMaxAbsRel;
+    if (errorMaxAbsRel < tol) {
+        testsPassed++;
+    } else {
+        reportEpsteinZetaError(valZeta, valZetaReg, errorMaxAbsRel, tol, mLat, dim,
+                               nu, xLat, yLat);
+    }
+    totalTests++;
 
     printf("\n\t ... ");
     printf("%d out of %d tests passed with tolerance %E.", testsPassed, totalTests,


### PR DESCRIPTION
# Fix Zreg at $\nu = 0$, $\boldsymbol{x}\in\Lambda$
- [x] fix func eval
- [x] add tests that catch this error next time
- [x] Changelog

## Problem & Solution

A wrong phase in the early return for $\nu=0$ of Zreg (fixed by the following diff)
```sh
         if (dot(dim, x_t2, x_t2) == 0 && nu == 0) {
-            res = -1 * cexp(-2 * M_PI * I * dot(dim, x_t1, y_t2));
+            if (reg) {
+                res = -1; // reg already carries phase by definition
+            } else {
+                res = -cexp(-2 * M_PI * I * dot(dim, x_t1, y_t2));
+            }
         } 
```
caused discontinuities near $\nu=0$ that do NOT appear if we look at the absolute values but are visible in the Imaginary and Real values
<img width="676" height="332" alt="grafik" src="https://github.com/user-attachments/assets/bc3cdcbd-b46e-4126-a22c-a9023fa2c7ff" />

Its clear that the correct value in $\nu=0$ is $-1$ both due to continuity in $\nu$ and since the singularity $\hat s$ is zero at $\nu=0$, so the regularized version is the same as the non regularized with an oscillatory factor that was missing in the special branch.

Now, after the fix, we have

<img width="676" height="332" alt="grafik" src="https://github.com/user-attachments/assets/dc498a0c-b3c0-4e2e-9460-73c84c3eddeb" />
