### PR TITLE
Fix scaling symmetry of regularized Epstein zeta function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 ## [0.6.2] - unreleased
 
+### Fixed
+- Release `v0.6.0` introduced silently wrong `epsteinZetaReg` return values for $\nu\in d+ 2\mathbb N_+$ and $\boldsymbol{y}\neq\boldsymbol{0}$ on lattices with $\operatorname{det}(A) \neq 1$, which also affected `epsteinZetaAnisoReg` for $\boldsymbol{\alpha}=\boldsymbol{0}$.
+
 ## [0.6.1] - 2026-08-11
 
 ### Fixed

--- a/src/crandall.c
+++ b/src/crandall.c
@@ -304,7 +304,7 @@ double polynomial_y_der(unsigned int k, unsigned int dim, const double *z,
                         unsigned int n) {
     // Return function if there is no derivative
     if (!alphaAbs) {
-        return real_int_pow(M_PI * dot(dim, z, z), k);
+        return real_int_pow(M_PI * dot(dim, z, z), k) / tgamma((double)n + 1);
     }
 
     unsigned int betaMin[dim];

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -1142,20 +1142,14 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, const double *m,
                    vol * inverse_imaginary_int_pow(alphaAbs) /
                    real_int_pow(-2 * M_PI, alphaAbs);
         } else {
-            if (k) {
-                double ySquared = 0;
-                for (int i = 0; i < dim; i++) {
-                    ySquared += y[i] * y[i];
-                }
-
-                res -= pow(M_PI, (double)(2 * k) + ((double)dim / 2)) /
-                       tgamma((double)k + ((double)dim / 2)) *
-                       negative_one_pow(k + 1) / tgamma((double)k + 1) *
-                       real_int_pow(ySquared, k) * log(ms * ms) / vol;
-            } else {
-                res += pow(M_PI, (double)dim / 2) / tgamma((double)dim / 2) *
-                       log(ms * ms) / vol;
+            double ySquared = 0;
+            for (int i = 0; i < dim; i++) {
+                ySquared += y[i] * y[i];
             }
+            res -= pow(M_PI, (double)(2 * k) + ((double)dim / 2)) /
+                   tgamma((double)k + ((double)dim / 2)) * negative_one_pow(k + 1) /
+                   tgamma((double)k + 1) * real_int_pow(ySquared, k) * log(ms * ms) /
+                   vol;
         }
     }
     return res;

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -1148,7 +1148,7 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, const double *m,
                     ySquared += y[i] * y[i];
                 }
 
-                res -= pow(M_PI, (double)(2 * k) + ((double)dim / 2)) *
+                res -= pow(M_PI, (double)(2 * k) + ((double)dim / 2)) /
                        tgamma((double)k + ((double)dim / 2)) *
                        negative_one_pow(k + 1) / tgamma((double)k + 1) *
                        real_int_pow(ySquared, k) * log(ms * ms) / vol;

--- a/src/zeta.c
+++ b/src/zeta.c
@@ -1135,7 +1135,7 @@ double complex epsteinZetaInternal(double nu, unsigned int dim, const double *m,
     // apply correction to matrix scaling if nu = d + 2k
     unsigned int k = (unsigned int)fmax(0., nearbyint((nu - (double)dim) / 2));
     if (reg && (nu == (dim + 2 * (double)k))) {
-        if (alphaAbs) {
+        if (aniso) {
             res -= pow(M_PI, (double)k + ((double)dim / 2)) /
                    tgamma((double)k + ((double)dim / 2)) * negative_one_pow(k + 1) *
                    polynomial_y_der(k, dim, y, alpha, alphaAbs, k) * log(ms * ms) /

--- a/tests/test_epsteinZeta.c
+++ b/tests/test_epsteinZeta.c
@@ -1126,6 +1126,101 @@ static int test_epsteinZeta_cutoff() {
 }
 
 /*!
+ * @brief Tests the scaling symmetry of the regularized Epstein zeta function at
+ * the exceptional exponents nu = dim + 2 * k.
+ *
+ * For a lattice with det(A) != 1, the internal rescaling of the
+ * lattice contributes a logarithmic correction term to the regularized Epstein
+ * zeta function. This test verifies the identity
+ *
+ *     Z^reg_{L,nu}(x, y) = s^nu Z^reg_{sL,nu}(s x, y / s)
+ *                          + (-1)^k pi^(2 k + dim / 2) / (V_L Gamma(k + dim / 2))
+ *                            * log(s^2) * (y . y)^k / k!
+ *
+ * for k in N_0 and s > 0.
+ *
+ * @return number of failed tests.
+ */
+static int test_epsteinZetaReg_scaling() { // NOLINT
+    printf("%s ", __func__);
+    double errorAbs;
+    double errorRel;
+    double errorMaxAbsRel;
+    double complex valZeta;
+    double complex valZetaScaled;
+
+    int testsPassed = 0;
+    int totalTests = 0;
+
+    double tol = pow(10, -13);
+    unsigned int dim = 2;
+    double m[] = {1., 1. / 2, 0., sqrt(3.) / 2};
+    double x[] = {0., 0.};
+    double y[] = {3. / 10, -1. / 5};
+    double vol = sqrt(3.) / 2;
+
+    double mScaled[4];
+    double xScaled[2];
+    double yScaled[2];
+
+    for (unsigned int k = 0; k <= 9; k++) {
+        double nu = (double)dim + (2. * (double)k);
+        for (int i = 0; i < 99; i++) {
+            double s = (3. / 5) + ((double)i * .4 / 5);
+
+            for (unsigned int j = 0; j < dim * dim; j++) {
+                mScaled[j] = s * m[j];
+            }
+            for (unsigned int j = 0; j < dim; j++) {
+                xScaled[j] = s * x[j];
+                yScaled[j] = y[j] / s;
+            }
+
+            double correction = negative_one_pow(k) *
+                                pow(M_PI, (2. * (double)k) + ((double)dim / 2)) /
+                                (vol * tgamma((double)k + ((double)dim / 2))) *
+                                log(s * s) * real_int_pow(dot(dim, y, y), k) /
+                                tgamma((double)k + 1.);
+
+            valZeta = epsteinZetaReg(nu, dim, m, x, y);
+            valZetaScaled =
+                pow(s, nu) * epsteinZetaReg(nu, dim, mScaled, xScaled, yScaled) +
+                correction;
+
+            errorAbs = errAbs(valZeta, valZetaScaled);
+            errorRel = errRel(valZeta, valZetaScaled);
+            errorMaxAbsRel = (errorAbs < errorRel) ? errorAbs : errorRel;
+
+            if (errorMaxAbsRel < tol) {
+                testsPassed++;
+            } else {
+                printf("\n");
+                printf("Warning! ");
+                printf("scaling symmetry:");
+                printf("   %0*.16lf %+.16lf I (epsteinZetaReg) \n\t\t\t  != "
+                       "%.16lf %+.16lf I (scaled lattice and correction)\n",
+                       4, creal(valZeta), cimag(valZeta), creal(valZetaScaled),
+                       cimag(valZetaScaled));
+                printf("Min(Emax, Erel):\t     %E !< %E  (tolerance)\n",
+                       errorMaxAbsRel, tol);
+                printf("\n");
+                printMatrixUnitTest("m:", m, (int)dim);
+                printf("nu:\t\t %.16lf\n", nu);
+                printf("s:\t\t %.16lf\n", s);
+                printVectorUnitTest("y:\t\t", y, (int)dim);
+            }
+            totalTests++;
+        }
+    }
+
+    printf("\n\t ... ");
+    printf("%d out of %d tests passed with tolerance %E.\n", testsPassed, totalTests,
+           tol);
+
+    return totalTests - testsPassed;
+}
+
+/*!
  * @brief Main function to run all Epstein zeta function tests.
  *
  * @return number of failed tests.
@@ -1140,5 +1235,6 @@ int main() {
     failed += run_timed_test(test_epsteinZeta_cutoff);
     failed += run_timed_test(test_epsteinZeta_epsteinZetaAniso_reduction);
     failed += run_timed_test(test_epsteinZetaReg_epsteinZetaAnisoReg_reduction);
+    failed += run_timed_test(test_epsteinZetaReg_scaling);
     return failed;
 }


### PR DESCRIPTION
- [x] Fix: error introduced in `v0.6.0` where `/` was erronously replaced with `*` in rescaling
- [x] Tests: so this does not happen again, formerly was not caught because only fires in special case of special case 
- [x] Changelog
- [ ] Redo long benchmarks for new release